### PR TITLE
Interruptible menus

### DIFF
--- a/trade.go
+++ b/trade.go
@@ -178,9 +178,11 @@ func start(cliCtx *cli.Context) error {
 
 	s := newSSHServer(cliCtx.GlobalString("listen"), signer)
 
-	inputChan := make(chan []byte)
+	inputChan := make(chan []byte, 1)
 	outputChan := make(chan []byte)
+
 	s.setChans(inputChan, outputChan)
+
 	if cliCtx.BoolT("use-dos") {
 		s.setCodec(charmap.CodePage437)
 	}
@@ -189,8 +191,8 @@ func start(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "Could not start SSH service")
 	}
 
-	mp := newMenuProxy()
-	mp.start(ctx, inputChan, outputChan, s)
+	mp := newMenuProxy(inputChan, outputChan)
+	mp.start(ctx)
 
 	return nil
 }


### PR DESCRIPTION
This allows for interruptible menus within the proxy. You can now press
Ctrl+e to enter the menu and shutdown the proxy if you need to. There is
also an option to re-attach.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>